### PR TITLE
[GD-65] feat: Image 컴포넌트 구현 및 스토리북 등록

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,15 +1,17 @@
+const path = require('path')
+
 module.exports = {
   stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
   addons: ['@storybook/addon-links', '@storybook/addon-essentials'],
   webpackFinal: async (config) => {
     config.resolve.alias['@components'] = path.resolve(
       __dirname,
-      '../src/components'
+      '../src/components',
     )
     config.resolve.alias['@hooks'] = path.resolve(__dirname, '../src/hooks')
     config.resolve.alias['@contexts'] = path.resolve(
       __dirname,
-      '../src/contexts'
+      '../src/contexts',
     )
     config.resolve.alias['@pages'] = path.resolve(__dirname, '../pages')
     return config

--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -1,0 +1,86 @@
+import styled from '@emotion/styled'
+import { useRef, useEffect, useState } from 'react'
+
+interface IImage {
+  src: string
+  block: boolean
+  iscircle: boolean
+  style?: React.CSSProperties
+  mode?: 'fill' | 'contain' | 'cover'
+  width?: number
+  height?: number
+  lazy?: boolean
+  threshold?: number
+  placeholder?: string
+}
+
+let observer = null
+const LOAD_IMG_EVENT_NAME = 'loadImage'
+
+const onIntersection: IntersectionObserverCallback = (entries, io) => {
+  entries.forEach((entry: IntersectionObserverEntry) => {
+    if (entry.isIntersecting) {
+      io.unobserve(entry.target)
+      entry.target.dispatchEvent(new CustomEvent(LOAD_IMG_EVENT_NAME))
+    }
+  })
+}
+
+const Image = ({
+  src,
+  block,
+  iscircle,
+  style,
+  mode = 'cover',
+  width = 180,
+  height = 240,
+  lazy = false,
+  threshold = 0.2,
+  placeholder = 'https://via.placeholder.com/180x240',
+}: IImage): JSX.Element => {
+  const [loaded, setLoaded] = useState<boolean>(false)
+  const imgRef = useRef<HTMLImageElement>(null)
+
+  const imageStyle: React.CSSProperties = {
+    display: block ? 'block' : 'inline',
+    objectFit: mode,
+    borderRadius: iscircle ? '50%' : undefined,
+    ...style,
+  }
+
+  useEffect(() => {
+    if (!lazy) {
+      setLoaded(true)
+
+      return
+    }
+    const handleLoadImage = () => setLoaded(true)
+    const imgElement = imgRef.current
+    imgElement &&
+      imgElement.addEventListener(LOAD_IMG_EVENT_NAME, handleLoadImage)
+
+    return () => {
+      imgElement &&
+        imgElement.removeEventListener(LOAD_IMG_EVENT_NAME, handleLoadImage)
+    }
+  }, [lazy])
+
+  useEffect(() => {
+    if (!lazy) return
+    observer = new IntersectionObserver(onIntersection, { threshold })
+    imgRef.current && observer.observe(imgRef.current)
+  }, [lazy, threshold])
+
+  return (
+    <img
+      ref={imgRef}
+      src={loaded ? src : placeholder}
+      alt="ImgError..."
+      width={width}
+      height={height}
+      style={{ ...imageStyle }}
+    />
+  )
+}
+
+export default Image

--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -1,14 +1,13 @@
-import styled from '@emotion/styled'
 import { useRef, useEffect, useState } from 'react'
 
 interface IImage {
   src: string
-  block: boolean
-  iscircle: boolean
   style?: React.CSSProperties
+  display?: string
+  iscircle?: boolean
   mode?: 'fill' | 'contain' | 'cover'
-  width?: number
-  height?: number
+  width?: number | string
+  height?: number | string
   lazy?: boolean
   threshold?: number
   placeholder?: string
@@ -28,9 +27,9 @@ const onIntersection: IntersectionObserverCallback = (entries, io) => {
 
 const Image = ({
   src,
-  block,
-  iscircle,
   style,
+  display = 'block',
+  iscircle = false,
   mode = 'cover',
   width = 180,
   height = 240,
@@ -42,7 +41,7 @@ const Image = ({
   const imgRef = useRef<HTMLImageElement>(null)
 
   const imageStyle: React.CSSProperties = {
-    display: block ? 'block' : 'inline',
+    display,
     objectFit: mode,
     borderRadius: iscircle ? '50%' : undefined,
     ...style,

--- a/src/stories/components/image.stories.tsx
+++ b/src/stories/components/image.stories.tsx
@@ -1,0 +1,53 @@
+import Image from '@components/Image'
+
+export default {
+  title: 'Components/Image',
+  component: Image,
+  argTypes: {
+    width: {
+      defaultValue: 180,
+      control: { type: 'number' },
+    },
+    height: {
+      defaultValue: 240,
+      control: { type: 'number' },
+    },
+    mode: {
+      defaultValue: 'contain',
+      options: ['cover', 'fill', 'contain'],
+      control: { type: 'inline-radio' },
+    },
+    block: {
+      defaultValue: false,
+      control: { type: 'boolean' },
+    },
+    lazy: {
+      defaultValue: false,
+      control: { type: 'boolean' },
+    },
+    threshold: {
+      defaultValue: 0.9,
+      control: { type: 'number' },
+    },
+    iscircle: {
+      defaultValue: false,
+      control: { type: 'boolean' },
+    },
+  },
+}
+
+export const Default = (args: any) => {
+  return (
+    <>
+      <Image src="https://picsum.photos/200" block={true} {...args} />
+      <Image src="https://picsum.photos/200" block={true} {...args} />
+      <Image src="https://picsum.photos/200" block={true} {...args} />
+      <Image
+        src="https://picsum.photos/200"
+        block={true}
+        style={{ marginLeft: '24px' }}
+        {...args}
+      />
+    </>
+  )
+}

--- a/src/stories/components/image.stories.tsx
+++ b/src/stories/components/image.stories.tsx
@@ -1,50 +1,31 @@
 import Image from '@components/Image'
 
+interface IImage {
+  style?: React.CSSProperties
+  display?: string
+  iscircle?: boolean
+  mode?: 'fill' | 'contain' | 'cover'
+  width?: number | string
+  height?: number | string
+  lazy?: boolean
+  threshold?: number
+  placeholder?: string
+}
+
 export default {
   title: 'Components/Image',
   component: Image,
-  argTypes: {
-    width: {
-      defaultValue: 180,
-      control: { type: 'number' },
-    },
-    height: {
-      defaultValue: 240,
-      control: { type: 'number' },
-    },
-    mode: {
-      defaultValue: 'contain',
-      options: ['cover', 'fill', 'contain'],
-      control: { type: 'inline-radio' },
-    },
-    block: {
-      defaultValue: false,
-      control: { type: 'boolean' },
-    },
-    lazy: {
-      defaultValue: false,
-      control: { type: 'boolean' },
-    },
-    threshold: {
-      defaultValue: 0.9,
-      control: { type: 'number' },
-    },
-    iscircle: {
-      defaultValue: false,
-      control: { type: 'boolean' },
-    },
-  },
 }
 
-export const Default = (args: any) => {
+export const Default = (args: IImage) => {
   return (
     <>
-      <Image src="https://picsum.photos/200" block={true} {...args} />
-      <Image src="https://picsum.photos/200" block={true} {...args} />
-      <Image src="https://picsum.photos/200" block={true} {...args} />
+      <Image src="https://picsum.photos/200" display="block" {...args} />
+      <Image src="https://picsum.photos/200" display="block" {...args} />
+      <Image src="https://picsum.photos/200" display="block" {...args} />
       <Image
         src="https://picsum.photos/200"
-        block={true}
+        display="block"
         style={{ marginLeft: '24px' }}
         {...args}
       />


### PR DESCRIPTION
## 🔥 Merge 대상이 Develop 브랜치가 맞는지 확인해주세요!!!

- [x] 반드시 확인 후 체크해주세요! ⁉️

## 🚀 PR 한 줄 요약

Image 컴포넌트 구현 및 스토리북 등록

## 🚸 PR 세부 내용

스토리북/main.js에 path 변수를 추가하였습니다. (번들 에러 원인)

Image 컴포넌트는 src, iscircle, block prop만을 필수로 전달받습니다.
이전 Lazy loading이 적용되어 있습니다. 
추후, 금일 가영님이 말씀하셨던 무한스크롤 훅을 사용할때 함께 사용하면 좋을 것 같습니다.

### 중점 리뷰
- Lazy Loading 필요 여부 : 꼭 필요할까..?
꼭 필요한가? 라는 생각이 있습니다. 개인적으로 무한스크롤 훅으로 선물함을 보여주면 기능이 조금 추가되지 않을까?라고 생각합니다.
아니라면! 추후 구현 여부에 따라 로직을 삭제해도 무방할 것 같습니다. Lazy 로직 삭제시 placeholder도 함께 삭제하면 될 것 같습니다.

- 인라인 스타일 관련 :  인라인 스타일을 최대한 지양하는것으로 알고 있습니다.
해당 이미지 컴포넌트를 사용하고자할때(첫번째 이미지) 마진과 같은 CSS 속성을 어떻게 받을 수 있을지 고민해보았습니다.
스타일드 컴포넌트와 Prop을 활용하는 방법도 생각해보았으나, HTML 요소에서 인라인 스타일 로직이 줄어들지 않았으며, 오히려 ${...} 같은 문법을 사용함으로써 가독성을 해친다고 생각했습니다.

따라서, 컴포넌트 내부에서 imageStyle 이라는 변수를 하나 생성하고 이를 스프레드 연산자로 사용하는 인라인 스타일로 지정을 하였습니다.

**아래 노션에 정리해놓았으니, 참고 부탁드리며 해당 부분 중점으로 리뷰해주시면 감사하겠습니다!!**
[FE노션](https://www.notion.so/backend-devcourse/FE-23ee80f2662b469dbb01654679bf349f?p=dc19c969456d4413babf607b87d10ebf)


<!-- 피드백을 반영한 부분이 있다면 해당 부분의 주석을 제거하고 사용해주세요!
## ⭕ 피드백 반영 사항

피드백 반영 사항에 대한 간단한 내용을 적어주세요.-->

## 📸 스크린샷

<img width="995" alt="스크린샷 2021-12-02 오전 1 48 16" src="https://user-images.githubusercontent.com/65607601/144279304-f9f9e0fe-bd7c-48e6-9d13-d8c4edc781a1.png">

https://user-images.githubusercontent.com/65607601/144279800-9b680a84-3b51-42f1-9a8d-45b68a889621.mp4