### PR TITLE
[GD-61] feat: MUIButton component, storybook 구현

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,15 +1,17 @@
+const path = require('path')
+
 module.exports = {
   stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
   addons: ['@storybook/addon-links', '@storybook/addon-essentials'],
   webpackFinal: async (config) => {
     config.resolve.alias['@components'] = path.resolve(
       __dirname,
-      '../src/components'
+      '../src/components',
     )
     config.resolve.alias['@hooks'] = path.resolve(__dirname, '../src/hooks')
     config.resolve.alias['@contexts'] = path.resolve(
       __dirname,
-      '../src/contexts'
+      '../src/contexts',
     )
     config.resolve.alias['@pages'] = path.resolve(__dirname, '../pages')
     return config

--- a/pages/sign.tsx
+++ b/pages/sign.tsx
@@ -9,12 +9,15 @@ const sign = () => {
     <>
       <MUIButton
         onClick={onButtonClick}
-        color={'white'}
-        height={'90px'}
-        width={'80%'}
-        text={'테스트버튼'}
-        border-radius={'50px'}
-        background-color={'red'}></MUIButton>
+        style={{
+          color: 'white',
+          height: '90px',
+          width: '80%',
+          borderRadius: '50px',
+          backgroundColor: 'red',
+        }}>
+        테스트버튼
+      </MUIButton>
     </>
   )
 }

--- a/pages/sign.tsx
+++ b/pages/sign.tsx
@@ -1,5 +1,22 @@
+import MUIButton from '@components/MUIButton'
+
 const sign = () => {
-  return <div>로그인 페이지</div>
+  const onButtonClick = () => {
+    alert('안녕')
+  }
+
+  return (
+    <>
+      <MUIButton
+        onClick={onButtonClick}
+        color={'white'}
+        height={'90px'}
+        width={'80%'}
+        text={'테스트버튼'}
+        border-radius={'50px'}
+        background-color={'red'}></MUIButton>
+    </>
+  )
 }
 
 export default sign

--- a/src/components/MUIButton/index.tsx
+++ b/src/components/MUIButton/index.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import Button from '@mui/material/Button'
+
+interface Props {
+  onClick?(): void
+  text?: string
+  color?: string
+  variant?: 'text' | 'contained' | 'outlined'
+  href?: string
+  height?: string
+  width?: string
+  backgroundColor?: string
+}
+
+const MUIButton: React.FC<Props> = ({
+  onClick,
+  text,
+  variant = 'contained',
+  href,
+  ...props
+}) => {
+  return (
+    <>
+      <Button
+        variant={variant}
+        href={href}
+        onClick={onClick}
+        style={{ ...props }}>
+        {text}
+      </Button>
+    </>
+  )
+}
+
+export default MUIButton

--- a/src/components/MUIButton/index.tsx
+++ b/src/components/MUIButton/index.tsx
@@ -1,25 +1,19 @@
-import React from 'react'
+import React, { CSSProperties } from 'react'
 import Button from '@mui/material/Button'
 
 interface Props {
   onClick?(): void
-  text?: string
-  color?: string
   variant?: 'text' | 'contained' | 'outlined'
   href?: string
-  height?: string
-  width?: string
-  backgroundColor?: string
-  borderRadius?: string
-  fontSize?: string
+  style?: CSSProperties
 }
 
 const MUIButton: React.FC<Props> = ({
   onClick,
-  text,
+  children,
   variant = 'contained',
   href,
-  ...props
+  style,
 }) => {
   return (
     <>
@@ -27,8 +21,8 @@ const MUIButton: React.FC<Props> = ({
         variant={variant}
         href={href}
         onClick={onClick}
-        style={{ ...props }}>
-        {text}
+        style={{ ...style }}>
+        {children}
       </Button>
     </>
   )

--- a/src/components/MUIButton/index.tsx
+++ b/src/components/MUIButton/index.tsx
@@ -10,6 +10,8 @@ interface Props {
   height?: string
   width?: string
   backgroundColor?: string
+  borderRadius?: string
+  fontSize?: string
 }
 
 const MUIButton: React.FC<Props> = ({

--- a/src/stories/Buttion.stories.tsx
+++ b/src/stories/Buttion.stories.tsx
@@ -1,0 +1,21 @@
+import Button from '@components/MUIButton'
+
+interface Props {
+  onClick?(): void
+  text?: string
+  color?: string
+  variant?: 'text' | 'contained' | 'outlined'
+  href?: string
+  height?: string
+  width?: string
+  backgroundColor?: string
+}
+
+export default {
+  title: 'Components/Button',
+  component: Button,
+}
+
+export const Default = (args: Props) => {
+  return <Button {...args}></Button>
+}

--- a/src/stories/Buttion.stories.tsx
+++ b/src/stories/Buttion.stories.tsx
@@ -1,23 +1,17 @@
+import { CSSProperties } from 'react'
 import Button from '@components/MUIButton'
 
 interface Props {
   onClick?(): void
-  text?: string
-  color?: string
   variant?: 'text' | 'contained' | 'outlined'
   href?: string
-  height?: string
-  width?: string
-  backgroundColor?: string
-  borderRadius?: string
-  fontSize?: string
+  style?: CSSProperties
 }
-
 export default {
   title: 'Components/Button',
   component: Button,
 }
 
 export const Default = (args: Props) => {
-  return <Button {...args}></Button>
+  return <Button {...args}>Button</Button>
 }

--- a/src/stories/Buttion.stories.tsx
+++ b/src/stories/Buttion.stories.tsx
@@ -9,6 +9,8 @@ interface Props {
   height?: string
   width?: string
   backgroundColor?: string
+  borderRadius?: string
+  fontSize?: string
 }
 
 export default {


### PR DESCRIPTION
## 🔥 Merge 대상이 Develop 브랜치가 맞는지 확인해주세요!!!

- [x] 반드시 확인 후 체크해주세요! ⁉️

## 🚀 PR 한 줄 요약

material Button 컴포넌트 및 스토리북 구현

## 🚸 PR 세부 내용

Button컴포넌트의 매게변수 중 variant, href, onClick(함수) 을 제외한
커스텀 디자인은 인라인 style로 지정

## 📸 스크린샷
![image](https://user-images.githubusercontent.com/52727782/144469235-24020cc2-9bad-4aa7-94eb-bba4258dd03f.png)

커스텀이 필요한 디자인이 있을 경우 style객체에서 정의하면 된다.