### PR TITLE
[GD-68] feat: Upload 컴포넌트 구현 및 스토리북 등록

### DIFF
--- a/src/components/Upload/index.tsx
+++ b/src/components/Upload/index.tsx
@@ -1,0 +1,239 @@
+import styled from '@emotion/styled'
+import React, { useState, useCallback, useRef, CSSProperties } from 'react'
+import { COLORS } from '@utils/constants/colors'
+import { FONT_SIZES } from '@utils/constants/sizes'
+
+interface IUpload {
+  id: string
+  name: string
+  value?: File
+  droppable: boolean
+  onChange?: any
+  onClick?: any
+  style?: CSSProperties
+}
+
+const Upload: React.FC<IUpload> = ({
+  id,
+  name,
+  value,
+  droppable,
+  onChange,
+  onClick,
+  style,
+  children,
+}): JSX.Element => {
+  const [file, setFile] = useState<File[] | null>(null)
+  // const [file, setFile] = useState<File[]>([])
+  const [dragging, setDragging] = useState(false)
+  // const [url, setUrl] = useState('')
+  const [url, setUrl] = useState('')
+  const [isShow, setIsShow] = useState(true)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const handleChooseFile = () => {
+    inputRef.current?.click()
+  }
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
+    e.preventDefault()
+    const files = e.target.files
+    if (files) {
+      console.log(files)
+      // 파일 하나인 경우
+      // const changedFile = files[0]
+      // const fileReader = new FileReader()
+      // fileReader.readAsDataURL(changedFile)
+      // console.log(fileReader, 11, fileReader.result)
+      // fileReader.onload = (e: any) => {
+      //   setUrl(e.target.result)
+      // }
+
+      //멅티플
+      Array.from(files).forEach((el: File) => {
+        const fileReader = new FileReader()
+        fileReader.readAsDataURL(el)
+        fileReader.onload = (e: any) => {
+          const url = e.target.result
+          // console.log([{ el, url }], el)
+          setFile((prev: []) => [...prev, { ...el, url }])
+        }
+      })
+
+      // const fileData: File[] = []
+      // const urlData: string[] = []
+      // const fileReader = new FileReader()
+      // Array.from(files).forEach((el: File) => {
+      //   console.log(el)
+      //   fileData.push(el)
+      //   fileReader.readAsDataURL(el)
+      //   fileReader.onload = (e: any) => {
+      //     console.log('onload')
+      //     urlData.push(e.target.result)
+      //     setUrl((prev) => prev.push(e.target.result))
+      //   }
+      // })
+      // console.log(fileData, 'fileData')
+      // console.log(urlData, 'urlData')
+      // setFile(fileData)
+      // setUrl(urlData)
+
+      // const fileReader = new FileReader()
+      // const fileData: File[] = Array.from(files).map((file) =>
+      //   {
+      //     fileReader.readAsDataURL(file)
+
+      //   }
+      // )
+      // console.log(fileData, 'fileData')
+      // setFile(fileData)
+
+      // const changedFile = files[0]
+      // const fileReader = new FileReader()
+      // fileReader.readAsDataURL(changedFile)
+      // console.log(fileReader, 11, fileReader.result)
+      // fileReader.onload = (e: any) => {
+      //   console.log(e.target.result)
+      // }
+
+      // fileData.forEach((el: File) => {
+      //   fileReader.readAsDataURL(el)
+      //   fileReader.onload = (e: any) => {
+      //     setUrl(e.target.result)
+      //   }
+      // })
+
+      // onChange && onChange(changedFile)
+    }
+  }
+
+  const handleRemoveOnClick = (e: any) => {
+    console.log('111')
+    e.stopPropagation()
+  }
+
+  const handleDragEnter = (e: React.DragEvent) => {
+    if (!droppable) return
+
+    e.preventDefault() // 브라우저 기본 이벤트를 막는다.
+    e.stopPropagation() // 부모나 자식 컴포넌트로 이벤트가 전파되는 것을 막는다.
+
+    if (e.dataTransfer.items && e.dataTransfer.items.length > 0) {
+      setDragging(true)
+    }
+  }
+  const handleDragLeave = (e: React.DragEvent) => {
+    if (!droppable) return
+
+    e.preventDefault()
+    e.stopPropagation()
+
+    setDragging(false)
+  }
+  const handleDragOver = (e: React.DragEvent) => {
+    if (!droppable) return
+
+    e.preventDefault()
+    e.stopPropagation()
+  }
+  const handleFileDrop = (e: React.DragEvent) => {
+    if (!droppable) return
+
+    e.preventDefault()
+    e.stopPropagation()
+
+    const files = e.dataTransfer.files
+    const changedFile = files[0]
+    // setFile(changedFile)
+    onChange && onChange(changedFile)
+    setDragging(false)
+  }
+  console.log(file, 'file')
+
+  return (
+    <>
+      {file ? (
+        file.map((element, index) => (
+          <UploadStyled
+            key={index}
+            onClick={handleChooseFile}
+            style={{ ...style }}>
+            <InputStyled
+              ref={inputRef}
+              type="file"
+              name={element.name}
+              accept="image/*"
+              onChange={handleFileChange}
+              multiple
+            />
+            {url ? (
+              <RemoveUpload onClick={handleRemoveOnClick}>x</RemoveUpload>
+            ) : (
+              <UploadBtn>+</UploadBtn>
+            )}
+            {url && <ImageStyled src={url ? url : ''} />}
+          </UploadStyled>
+        ))
+      ) : (
+        <UploadStyled onClick={handleChooseFile} style={{ ...style }}>
+          <InputStyled
+            ref={inputRef}
+            type="file"
+            name={name}
+            accept="image/*"
+            onChange={handleFileChange}
+            multiple
+          />
+          {url ? (
+            <RemoveUpload onClick={handleRemoveOnClick}>x</RemoveUpload>
+          ) : (
+            <UploadBtn>+</UploadBtn>
+          )}
+          {url && <ImageStyled src={url ? url : ''} />}
+        </UploadStyled>
+      )}
+    </>
+  )
+}
+
+const InputStyled = styled.input`
+  display: none;
+`
+
+const UploadStyled = styled.div`
+  display: inline-block;
+  width: 80px;
+  height: 120px;
+  background-color: ${COLORS.TEXT_GRAY_LIGHT};
+  cursor: pointer;
+`
+
+const ImageStyled = styled.img`
+  width: 80px;
+  height: 120px;
+  object-fit: cover;
+`
+
+const UploadBtn = styled.button`
+  color: ${COLORS.TEXT_BLACK};
+  font-size: ${FONT_SIZES.MEDIUM};
+  border: none;
+  background: none;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+`
+
+const RemoveUpload = styled.button`
+  color: ${COLORS.TEXT_BLACK};
+  font-size: ${FONT_SIZES.MEDIUM};
+  background: ${COLORS.RED};
+  color: ${COLORS.WHITE};
+  border: none;
+  position: absolute;
+  right: 0;
+  border-radius: 50%;
+`
+
+export default Upload

--- a/src/stories/components/Upload.stories.tsx
+++ b/src/stories/components/Upload.stories.tsx
@@ -1,0 +1,30 @@
+import Upload from '@components/Upload'
+import styled from '@emotion/styled'
+
+export default {
+  title: 'Components/Upload',
+  component: Upload,
+}
+
+export const Default = () => {
+  return (
+    <>
+      <Upload id="1" name="abc" droppable style={{ position: 'relative' }} />
+      <Upload id="2" name="cc" droppable style={{ position: 'relative' }} />
+    </>
+  )
+}
+
+export const Multiple = () => {
+  return <Upload id="1" name="abc" droppable style={{ position: 'relative' }} />
+}
+
+const Btn = styled.button`
+  border: none;
+  background: none;
+  font-size: 1.5rem;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+`

--- a/src/stories/components/Upload.stories.tsx
+++ b/src/stories/components/Upload.stories.tsx
@@ -1,5 +1,5 @@
 import Upload from '@components/Upload'
-import styled from '@emotion/styled'
+import { useState } from 'react'
 
 export default {
   title: 'Components/Upload',
@@ -7,24 +7,18 @@ export default {
 }
 
 export const Default = () => {
+  const [files, setFiles] = useState<File[]>([])
+
+  const testShowfiles = (fileList: File[]) => {
+    console.log('자식으로 부터 전달된 파일 리스트', fileList)
+    setFiles(fileList)
+  }
+
+  console.log('부모에서의 파일 상태 리스트', files)
+
   return (
     <>
-      <Upload id="1" name="abc" droppable style={{ position: 'relative' }} />
-      <Upload id="2" name="cc" droppable style={{ position: 'relative' }} />
+      <Upload id="upload" name="abc" onClick={testShowfiles} />
     </>
   )
 }
-
-export const Multiple = () => {
-  return <Upload id="1" name="abc" droppable style={{ position: 'relative' }} />
-}
-
-const Btn = styled.button`
-  border: none;
-  background: none;
-  font-size: 1.5rem;
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-`


### PR DESCRIPTION
## 🔥 Merge 대상이 Develop 브랜치가 맞는지 확인해주세요!!!

- [x] 반드시 확인 후 체크해주세요! ⁉️

## 🚀 PR 한 줄 요약

Upload 컴포넌트 구현 및 스토리북 등록

## 🚸 PR 세부 내용

- 추가 버튼으로 컴포넌트를 불러올 필요가 없다고 판단하였습니다. 이미지를 넣는 것에 따라 자동으로 계속해서 이미지를 받을 수 있습니다.
- 드래그 기능은 제외하였습니다. 모바일 버전으로 필요없다고 판단했습니다. (추가로 필요하다면 이는 생각보다 간단해서 구현하는데 문제 없다고 판단합니다!)
- 모든 이미지를 받을 수 있으며, 최대 10개로 갯수를 제한하였습니다.
- 스토리북에서 부모에서 어떤 파일이 업로드되었는지 파일 객체에 대한 배열을 상태로 가질 수 있습니다.
- MUI 버튼은 적용하지 못했습니다.

<!-- 피드백을 반영한 부분이 있다면 해당 부분의 주석을 제거하고 사용해주세요!
## ⭕ 피드백 반영 사항

피드백 반영 사항에 대한 간단한 내용을 적어주세요.-->

## 📸 스크린샷

https://user-images.githubusercontent.com/65607601/144754488-ba2641f0-0daa-481d-a638-35f49ee1ee96.mp4
