### PR TITLE
[GD]102] feat: UserProvider Context API 기능 구현

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,12 +1,16 @@
 import { AppProps } from 'next/app'
 import styled from '@emotion/styled'
 import '../styles/globals.css'
+import UserProvider from '@contexts/UserProvider'
+
 function App({ Component, pageProps }: AppProps) {
   return (
     <>
-      <RootContainer>
-        <Component {...pageProps}></Component>
-      </RootContainer>
+      <UserProvider>
+        <RootContainer>
+          <Component {...pageProps}></Component>
+        </RootContainer>
+      </UserProvider>
     </>
   )
 }

--- a/pages/testPageMuntari.tsx
+++ b/pages/testPageMuntari.tsx
@@ -1,0 +1,14 @@
+import { useUserContext } from '@contexts/UserProvider'
+import { useEffect } from 'react'
+
+const testPageMuntari = () => {
+  const { token } = useUserContext()
+
+  useEffect(() => {
+    console.log(token)
+  })
+
+  return <h1>token</h1>
+}
+
+export default testPageMuntari

--- a/pages/testPageMuntari.tsx
+++ b/pages/testPageMuntari.tsx
@@ -2,14 +2,19 @@ import { useUserContext } from '@contexts/UserProvider'
 import { useEffect } from 'react'
 
 const testPageMuntari = () => {
-  const { token, user, clearStorage } = useUserContext()
+  const { token, user, clearToken, clearUser } = useUserContext()
 
   useEffect(() => {
     console.log('Token', token)
     console.log('User', user)
   })
 
-  return <button onClick={clearStorage}>ClearStorage</button>
+  return (
+    <>
+      <button onClick={clearToken}>clearToken</button>
+      <button onClick={clearUser}>clearUser</button>
+    </>
+  )
 }
 
 export default testPageMuntari

--- a/pages/testPageMuntari.tsx
+++ b/pages/testPageMuntari.tsx
@@ -2,13 +2,14 @@ import { useUserContext } from '@contexts/UserProvider'
 import { useEffect } from 'react'
 
 const testPageMuntari = () => {
-  const { token } = useUserContext()
+  const { token, user, clearStorage } = useUserContext()
 
   useEffect(() => {
-    console.log(token)
+    console.log('Token', token)
+    console.log('User', user)
   })
 
-  return <h1>token</h1>
+  return <button onClick={clearStorage}>ClearStorage</button>
 }
 
 export default testPageMuntari

--- a/src/contexts/UserProvider.tsx
+++ b/src/contexts/UserProvider.tsx
@@ -4,7 +4,8 @@ import { createContext, ReactChild, useCallback, useContext } from 'react'
 interface IUserContext {
   token: string[]
   user: object
-  clearStorage(): void
+  clearToken(): void
+  clearUser(): void
 }
 
 interface Props {
@@ -18,12 +19,16 @@ const UserProvider = ({ children }: Props) => {
   const [token, setToken] = useLocalStorage<string[]>('Token', [])
   const [user, setUser] = useLocalStorage<object[]>('User', [])
 
-  const clearStorage = useCallback(() => {
-    localStorage.clear()
+  const clearToken = useCallback(() => {
+    setToken([])
+  }, [])
+
+  const clearUser = useCallback(() => {
+    setUser([])
   }, [])
 
   return (
-    <UserContext.Provider value={{ token, user, clearStorage }}>
+    <UserContext.Provider value={{ token, user, clearToken, clearUser }}>
       {children}
     </UserContext.Provider>
   )

--- a/src/contexts/UserProvider.tsx
+++ b/src/contexts/UserProvider.tsx
@@ -1,0 +1,23 @@
+import useLocalStorage from '@hooks/useLocalStorage'
+import { createContext, ReactChild, useContext } from 'react'
+
+interface IUserContext {
+  token?: string[]
+}
+
+interface Props {
+  children: ReactChild
+}
+
+const UserContext = createContext<IUserContext>({} as IUserContext)
+export const useUserContext = () => useContext(UserContext)
+
+const UserProvider = ({ children }: Props) => {
+  const [token, setToken] = useLocalStorage<string[]>('token', [])
+
+  return (
+    <UserContext.Provider value={{ token }}>{children}</UserContext.Provider>
+  )
+}
+
+export default UserProvider

--- a/src/contexts/UserProvider.tsx
+++ b/src/contexts/UserProvider.tsx
@@ -1,8 +1,10 @@
 import useLocalStorage from '@hooks/useLocalStorage'
-import { createContext, ReactChild, useContext } from 'react'
+import { createContext, ReactChild, useCallback, useContext } from 'react'
 
 interface IUserContext {
-  token?: string[]
+  token: string[]
+  user: object
+  clearStorage(): void
 }
 
 interface Props {
@@ -13,10 +15,17 @@ const UserContext = createContext<IUserContext>({} as IUserContext)
 export const useUserContext = () => useContext(UserContext)
 
 const UserProvider = ({ children }: Props) => {
-  const [token, setToken] = useLocalStorage<string[]>('token', [])
+  const [token, setToken] = useLocalStorage<string[]>('Token', [])
+  const [user, setUser] = useLocalStorage<object[]>('User', [])
+
+  const clearStorage = useCallback(() => {
+    localStorage.clear()
+  }, [])
 
   return (
-    <UserContext.Provider value={{ token }}>{children}</UserContext.Provider>
+    <UserContext.Provider value={{ token, user, clearStorage }}>
+      {children}
+    </UserContext.Provider>
   )
 }
 


### PR DESCRIPTION
## 🔥 Merge 대상이 Develop 브랜치가 맞는지 확인해주세요!!!

- [x] 반드시 확인 후 체크해주세요! ⁉️

## 🚀 PR 한 줄 요약

UserProvider Context API 기능 구현

## 🚸 PR 세부 내용

- 현재 UserProvider 역할은 로컬 스토리지의 토큰을 가져오는 것입니다.
useUserContext() 를 실행하여 Store의 토큰 값을 꺼내와 사용 할 수 있습니다.

- testPageMuntari.tsx 에서 사용법 확인부탁드립니다.

- 변수명 피드백 부탁드립니다!

<!-- 피드백을 반영한 부분이 있다면 해당 부분의 주석을 제거하고 사용해주세요!-->
## ⭕ 피드백 반영 사항

- 유저 정보를 스토리지에 저장한다는 가정으로 유저 정보를 컨텍스트에서 상태로 가지고 있습니다.
  - 유저 이름, 유저 이메일, 유저 프로필만을 저장합니다. id 같은 정보는 빼는게 맞다고 생각합니다만 의견 부탁드립니다.

- 스토리지를 비우는 행동 자체가 로그아웃입니다.

## 📸 스크린샷
<img width="1253" alt="스크린샷 2021-12-07 오후 8 49 12" src="https://user-images.githubusercontent.com/65607601/145024174-47489390-ff89-481b-a460-c04894917d0b.png">
<img width="1253" alt="스크린샷 2021-12-07 오후 8 49 07" src="https://user-images.githubusercontent.com/65607601/145024188-47a98223-8f43-47bf-b3a2-7ebf7f372637.png">


