### PR TITLE
[GD-112] feat: TimerHeader 도메인 컴포넌트 구현 및 Sizes LARGER 추가

### DIFF
--- a/pages/fifo/[url].tsx
+++ b/pages/fifo/[url].tsx
@@ -5,6 +5,7 @@ import { COLORS } from '@utils/constants/colors'
 import Image from '@components/Image'
 import MUIButton from '@components/MUIButton'
 import { useRouter } from 'next/dist/client/router'
+import TimerHeader from '@domains/TimerHeader'
 
 const fifo = () => {
   const router = useRouter()
@@ -14,11 +15,9 @@ const fifo = () => {
   }
 
   return (
-    <FifoContainer>
+    <>
       <Header />
-      <Text>텍스트 컴포넌트</Text>
-      <Timer>타이머 컴포넌트</Timer>
-      <TimerText>텍스트 컴포넌트</TimerText>
+      <TimerHeader />
       <GiftWrapper>
         <Gift>
           <Image
@@ -44,68 +43,10 @@ const fifo = () => {
             GET
           </MUIButton>
         </Gift>
-        <Gift>
-          <Image
-            src="/vercel.svg"
-            width={'60px'}
-            height={'60px'}
-            mode="contain"
-            style={{ backgroundColor: 'white' }}
-          />
-          <GiftTextWrapper>
-            <GiftTitle>시원한 아이스 아메리카노</GiftTitle>
-            <GiftQuantity>수량 : 5개</GiftQuantity>
-          </GiftTextWrapper>
-          <MUIButton
-            onClick={onButtonClick}
-            style={{
-              color: 'white',
-              height: '36px',
-              width: '86px',
-              borderRadius: '50px',
-              backgroundColor: 'red',
-            }}>
-            GET
-          </MUIButton>
-        </Gift>
       </GiftWrapper>
-    </FifoContainer>
+    </>
   )
 }
-
-const FifoContainer = styled.div`
-  width: 100%;
-  height: 100%;
-  background-color: blue;
-  display: flex;
-  flex-direction: column;
-  position: relative;
-  align-items: center;
-`
-
-const Text = styled.text`
-  font-size: ${FONT_SIZES.MEDIUM};
-  color: ${COLORS.WHITE};
-  background-color: gray;
-  position: absolute;
-  top: 120px;
-`
-
-const Timer = styled.div`
-  font-size: ${FONT_SIZES.LARGE};
-  color: ${COLORS.WHITE};
-  background-color: gray;
-  position: absolute;
-  top: 180px;
-`
-
-const TimerText = styled.text`
-  font-size: ${FONT_SIZES.SMALL};
-  color: ${COLORS.WHITE};
-  background-color: gray;
-  position: absolute;
-  top: 200px;
-`
 
 const GiftWrapper = styled.div`
   width: 100%;
@@ -115,7 +56,6 @@ const GiftWrapper = styled.div`
   height: 60vh;
   padding-left: ${DEFAULT_MARGIN};
   padding-right: ${DEFAULT_MARGIN};
-  background-color: greenyellow;
 `
 
 const Gift = styled.div`

--- a/pages/testPageMuntari.tsx
+++ b/pages/testPageMuntari.tsx
@@ -1,0 +1,7 @@
+import TimerHeader from '@domains/TimerHeader'
+
+const testPageMuntari = () => {
+  return <TimerHeader />
+}
+
+export default testPageMuntari

--- a/pages/testPageMuntari.tsx
+++ b/pages/testPageMuntari.tsx
@@ -1,7 +1,0 @@
-import TimerHeader from '@domains/TimerHeader'
-
-const testPageMuntari = () => {
-  return <TimerHeader />
-}
-
-export default testPageMuntari

--- a/src/domains/TimerHeader/index.tsx
+++ b/src/domains/TimerHeader/index.tsx
@@ -1,0 +1,73 @@
+import styled from '@emotion/styled'
+import Text from '@components/Text'
+import Timer from '@components/Timer'
+import { useRouter } from 'next/dist/client/router'
+import { useEffect } from 'react'
+
+const startDate = new Date(2021, 12, 8, 0, 0, 0)
+
+const MOCK_TIMER_DATA = {
+  eventStart: startDate,
+  eventMaster: '도가가',
+}
+
+const TimerHeader = (): JSX.Element => {
+  const router = useRouter()
+
+  useEffect(() => {
+    console.log('TimerHeader', router)
+    console.log('GetParams', router.query['url'])
+  }, [router])
+
+  return (
+    <TimerHeaderContainer>
+      <TextWrapper>
+        <Text
+          size="LARGE"
+          color="WHITE"
+          style={{
+            display: 'inline',
+            textDecoration: 'underline',
+            fontWeight: 'bold',
+          }}>
+          {MOCK_TIMER_DATA.eventMaster}
+        </Text>
+        <Text size="LARGE" color="WHITE" style={{ display: 'inline' }}>
+          님이 준비한 선물입니다!
+        </Text>
+      </TextWrapper>
+      <TimerWrapper>
+        <Timer size="LARGER" time={MOCK_TIMER_DATA.eventStart} />
+        <Text size="MEDIUM" color="TEXT_GRAY_DARK" style={{ marginTop: '8px' }}>
+          선착순이니 서둘러주세요!!
+        </Text>
+      </TimerWrapper>
+    </TimerHeaderContainer>
+  )
+}
+
+const TimerHeaderContainer = styled.div`
+  width: 70%;
+  margin: 0 auto;
+  margin-top: 35%;
+  @media all and (max-width: 425px) {
+    margin-top: 20%;
+  }
+`
+
+const TextWrapper = styled.div`
+  width: 100%;
+  text-align: center;
+`
+
+const TimerWrapper = styled.div`
+  width: 85%;
+  margin: 0 auto;
+  text-align: center;
+  margin-top: 40px;
+  @media all and (max-width: 425px) {
+    margin-top: 24px;
+  }
+`
+
+export default TimerHeader

--- a/src/domains/TimerHeader/index.tsx
+++ b/src/domains/TimerHeader/index.tsx
@@ -4,7 +4,7 @@ import Timer from '@components/Timer'
 import { useRouter } from 'next/dist/client/router'
 import { useEffect } from 'react'
 
-const startDate = new Date(2021, 12, 8, 0, 0, 0)
+const startDate = new Date('12/9/2021')
 
 const MOCK_TIMER_DATA = {
   eventStart: startDate,

--- a/src/utils/constants/sizes.ts
+++ b/src/utils/constants/sizes.ts
@@ -8,7 +8,7 @@ export const FONT_SIZES: IFontSize = {
   BASE: '1rem',
   MEDIUM: '1.125rem',
   LARGE: '1.5rem',
-  LARGER: '2rem',
+  LARGER: '4rem',
 }
 
 export const DEFAULT_MARGIN = '16px'

--- a/src/utils/constants/sizes.ts
+++ b/src/utils/constants/sizes.ts
@@ -8,6 +8,7 @@ export const FONT_SIZES: IFontSize = {
   BASE: '1rem',
   MEDIUM: '1.125rem',
   LARGE: '1.5rem',
+  LARGER: '2rem',
 }
 
 export const DEFAULT_MARGIN = '16px'


### PR DESCRIPTION
## 🔥 Merge 대상이 Develop 브랜치가 맞는지 확인해주세요!!!

- [x] 반드시 확인 후 체크해주세요! ⁉️

## 🚀 PR 한 줄 요약

TimerHeader 도메인 컴포넌트 구현 및 Sizes LARGER 추가

## 🚸 PR 세부 내용

- TimerHeader
1. 해당 컴포넌트에서 url의 쿼리스트링을 확인하여 이를 통해 어떤 이벤트인지, 누구의 이벤트인지, 시작시간은 언제인지를 부모에서 Prop으로 받을지 해당 컴포넌트에서 API 로직을 사용할지는 정하지 못했습니다.
추후 방향에 따라 수정하겠습니다.

2. 모바일 & 브라우저에서 해당 컴포넌트 위치가 마음에 들지 않아 반응형 적용하였습니다. 
기준은 MobileL 425px기준입니다.

- Sizes
~~타이머의 글씨가 작아 LARGER = 2rem 추가하였습니다.~~

<!-- 피드백을 반영한 부분이 있다면 해당 부분의 주석을 제거하고 사용해주세요!-->
## ⭕ 피드백 반영 사항
- Sizes
LARGER = 4rem 추가하였습니다.

## 📸 스크린샷

### 브라우저
<img width="372" alt="스크린샷 2021-12-08 오전 12 58 54" src="https://user-images.githubusercontent.com/65607601/145063595-5829b17d-d71f-4be3-80c3-c25556b5f822.png">

### 모바일
![image](https://user-images.githubusercontent.com/65607601/145160923-88c2d5a2-4bd2-445e-a0d6-9f5a0eb99fcf.png)


