### PR TITLE
[GD-56] style: Stepper, EventTitle 디자인수정

### DIFF
--- a/pages/post.tsx
+++ b/pages/post.tsx
@@ -169,7 +169,7 @@ const DisplayStyle = styled.div`
   ${({ activeStep }: Props) => {
     return activeStep === 0
       ? css`
-          display: none;
+          visibility: hidden;
         `
       : css`
           display: black;

--- a/src/domains/EventTitle/index.tsx
+++ b/src/domains/EventTitle/index.tsx
@@ -59,13 +59,20 @@ const EventTitle: React.FC<Props> = ({
 
         <Div>
           <Box sx={{ flexGrow: 1 }}>
-            <Grid container columnSpacing={2} rowSpacing={6}>
+            <Grid
+              container
+              columnSpacing={4}
+              rowSpacing={1}
+              style={{
+                justifyContent: 'center',
+              }}>
               {Array.from(Array(6)).map((_, index) => (
                 <Grid item sm={4} key={index}>
                   <Image
                     src={`/cover/cover${index + 1}.png`}
-                    width={120}
-                    height={160}
+                    width={100}
+                    height={140}
+                    style={{ borderRadius: '10px' }}
                   />
                   <Div>
                     <label htmlFor={`cover${index + 1}`}>{`cover${
@@ -90,11 +97,11 @@ const EventTitle: React.FC<Props> = ({
 }
 
 const EventTitleContainer = styled.div`
-  margin-top: 10%;
+  padding-top: 5%;
 `
 
 const Div = styled.div`
-  padding-top: 10%;
+  padding-top: 5%;
   width: calc(100% - 32px);
   margin: 0 auto;
   display: flex;


### PR DESCRIPTION
## 🔥 Merge 대상이 Develop 브랜치가 맞는지 확인해주세요!!!

- [x] 반드시 확인 후 체크해주세요! ⁉️

## 🚀 PR 한 줄 요약

post 페이지 stepper, EventTitle(step1) 디자인 수정


## 🚸 PR 세부 내용

1. 기존 steeper step1 에서는 Back 버튼이 안보여야 하기 때문에
display : none 처리를 했지만, none 처리 시 요소 차지도 안 하기 때문에
Back버튼 위치에 Next 버튼이 보이는 현상이 있어서
요소 차지는 하되, 보이지 않게  `visibility: hidden;` 처리

2. EventTitle (step1)에서 요소의 크기 떄문에 화면 짤림이 발생
이미지 요소를 조절하여 수정

## 📸 스크린샷
![image](https://user-images.githubusercontent.com/52727782/145670774-74645805-e64d-4331-adb6-c0681a8fb9ed.png)

