### PR TITLE
[GD-175] fix: 선물 타입에 따른 꽝 수량 기능 수정

### DIFF
--- a/pages/post.tsx
+++ b/pages/post.tsx
@@ -33,7 +33,6 @@ const post = () => {
   // 사용자 정보 API
   const getUserData = useCallback(async () => {
     const res = await getUesrInfo()
-    console.log(res)
     setMemberId(res.id)
     res ? updateUser(res) : router.replace('/login')
   }, [])
@@ -198,6 +197,8 @@ const post = () => {
             gifts={gifts}
             AddGiftItem={AddGiftItem}
             delteGiftItem={delteGiftItem}
+            maxParticipantCount={maxParticipantCount}
+            giftChoiceType={giftChoiceType}
           />
         )
       case 3:

--- a/pages/post.tsx
+++ b/pages/post.tsx
@@ -218,9 +218,7 @@ const post = () => {
   return (
     <>
       {activeStep === steps.length ? (
-        <EventComplete
-          eventLink={eventLink}
-          giftChoiceType={giftChoiceType}></EventComplete>
+        <EventComplete eventLink={eventLink} giftChoiceType={giftChoiceType} />
       ) : (
         <PostContainer>
           <Stepper

--- a/src/domains/EventPresent/index.tsx
+++ b/src/domains/EventPresent/index.tsx
@@ -130,17 +130,10 @@ const EventPresent = ({
               title="선물 등록"
               handleStateClear={handleStateClear}
               confirm>
-              <div
-                style={{
-                  display: 'flex',
-                  border: '1px dashed white',
-                  width: '50px',
-                  height: '50px',
-                  justifyContent: 'center',
-                  alignItems: 'center',
-                }}>
+              <ItemForm>
                 <Icon name="plus" color="WHITE" size="LARGE"></Icon>
-              </div>
+              </ItemForm>
+
               <PresentModal
                 category={category}
                 content={content}
@@ -177,14 +170,7 @@ const EventPresent = ({
             })}
         </GiftWrapper>
 
-        <DisplayStyle
-          giftChoiceType={giftChoiceType}
-          style={{
-            padding: '10px 0 0 12px',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-          }}>
+        <DisplayStyle giftChoiceType={giftChoiceType}>
           <Image src={noting.src} width="60px" height="60px" />
           <div>
             <Text size="MEDIUM" color="WHITE">
@@ -229,11 +215,24 @@ const GiftWrapper = styled.div`
     display: none; /* Chrome, Safari, Opera*/
   }
 `
+const ItemForm = styled.div`
+  display: flex;
+  border: 1px dashed white;
+  width: 50px;
+  height: 50px;
+  justify-content: center;
+  align-items: center;
+`
+
 const DisplayStyle = styled.div`
   ${({ giftChoiceType }: Display) => {
     return giftChoiceType === 'RANDOM'
       ? css`
           display: black;
+          padding: 10px 0 0 12px;
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
         `
       : css`
           visibility: hidden;

--- a/src/domains/EventPresent/index.tsx
+++ b/src/domains/EventPresent/index.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 import styled from '@emotion/styled'
+import { css } from '@emotion/react'
 import Image from '@components/Image'
 import { DEFAULT_MARGIN } from '@utils/constants/sizes'
 import Swal from 'sweetalert2'
@@ -12,10 +13,16 @@ import MUIButton from '@components/MUIButton'
 import PresentModal from './PresentModal'
 import GiftForm from './GiftForm'
 
+interface Display {
+  giftChoiceType: string
+}
+
 interface Props {
   gifts: Gift[]
   AddGiftItem(e: Gift): void
   delteGiftItem(e: string): void
+  maxParticipantCount: number | undefined
+  giftChoiceType: string
 }
 
 interface Gift {
@@ -30,7 +37,13 @@ interface GiftItem {
   giftType: 'TEXT' | 'IMAGE'
 }
 
-const EventPresent = ({ gifts, AddGiftItem, delteGiftItem }: Props) => {
+const EventPresent = ({
+  gifts,
+  AddGiftItem,
+  delteGiftItem,
+  maxParticipantCount = 0,
+  giftChoiceType,
+}: Props) => {
   const [category, setCategory] = useState('')
   const [content, setContent] = useState('')
   const [contentList, setContentList] = useState<GiftItem[]>([])
@@ -105,7 +118,7 @@ const EventPresent = ({ gifts, AddGiftItem, delteGiftItem }: Props) => {
               color="RED"
               size="LARGE"
               style={{ cursor: 'auto' }}></Icon>
-            <Text size="MICRO">{`${totalQuantity}개`}</Text>
+            <Text size="MICRO">{totalQuantity}개</Text>
           </div>
           <div
             style={{
@@ -164,7 +177,8 @@ const EventPresent = ({ gifts, AddGiftItem, delteGiftItem }: Props) => {
             })}
         </GiftWrapper>
 
-        <div
+        <DisplayStyle
+          giftChoiceType={giftChoiceType}
           style={{
             padding: '10px 0 0 12px',
             display: 'flex',
@@ -180,7 +194,7 @@ const EventPresent = ({ gifts, AddGiftItem, delteGiftItem }: Props) => {
               size="BASE"
               color="TEXT_GRAY_DARK"
               style={{ paddingTop: '3px' }}>
-              수량 : 10 개
+              수량 : {maxParticipantCount - totalQuantity} 개
             </Text>
           </div>
           <div>
@@ -188,7 +202,7 @@ const EventPresent = ({ gifts, AddGiftItem, delteGiftItem }: Props) => {
               * 등록한 선물이 부족하면 꽝으로 채워집니다.
             </Text>
           </div>
-        </div>
+        </DisplayStyle>
       </EventPresentContainer>
     </>
   )
@@ -214,6 +228,17 @@ const GiftWrapper = styled.div`
   &::-webkit-scrollbar {
     display: none; /* Chrome, Safari, Opera*/
   }
+`
+const DisplayStyle = styled.div`
+  ${({ giftChoiceType }: Display) => {
+    return giftChoiceType === 'RANDOM'
+      ? css`
+          display: black;
+        `
+      : css`
+          visibility: hidden;
+        `
+  }}
 `
 
 export default EventPresent


### PR DESCRIPTION
## 🔥 Merge 대상이 Develop 브랜치가 맞는지 확인해주세요!!!

- [x] 반드시 확인 후 체크해주세요! ⁉️

## 🚀 PR 한 줄 요약

선물 타입에 따른 꽝 수량 기능 수정

## 🚸 PR 세부 내용

- 랜덤 이벤트 생성 시 꽝 수량 = 참여자 - 선물 수량이다.
- 선착순 일 경우, 꽝 수량이 필요없기 때문에 display none처리
- 그외에 간단한 style emotion으로 분리했습니다.

## 📸 스크린샷
랜덤 선물 타입, 참여자10명,  만든 선물1개일 때,
![image](https://user-images.githubusercontent.com/52727782/146642531-6c0e08c2-113e-4915-9efc-4c6393961b58.png)

선착순 선물 타입 시
![image](https://user-images.githubusercontent.com/52727782/146642535-bfa6c5d2-f990-4cea-9d3c-b5c654bee030.png)