### PR TITLE
[GD-182] feat: 이벤트 종료에 따른 당첨자 목록 처리

### DIFF
--- a/pages/api/services/event.ts
+++ b/pages/api/services/event.ts
@@ -3,7 +3,8 @@ import {
   IEventList,
   IPagination,
   IEventItem,
-  IWinners,
+  IWinnerList,
+  IWinner,
   IFilteredWinners,
 } from 'types/event'
 
@@ -62,15 +63,17 @@ export const eventDetail = ({
 }
 
 export const eventWinnerList = (
-  winnerList: IWinners[],
+  winnerList: IWinnerList[],
 ): IFilteredWinners[] | undefined => {
-  return winnerList?.map(({ category, winners }: IWinners) => {
+  return winnerList?.map(({ category, winners }: IWinnerList) => {
     return {
       category,
-      winners: {
-        _id: winners.id?.toString(),
-        name: winners.name,
-      },
+      winners: winners?.map(({ id, name }: IWinner) => {
+        return {
+          _id: String(id),
+          name,
+        }
+      }),
     }
   })
 }

--- a/pages/api/services/event.ts
+++ b/pages/api/services/event.ts
@@ -5,7 +5,7 @@ import {
   IEventItem,
   IWinnerList,
   IWinner,
-  IFilteredWinners,
+  IFilteredWinnerList,
 } from 'types/event'
 
 export const filteredEventList = ({
@@ -64,7 +64,7 @@ export const eventDetail = ({
 
 export const eventWinnerList = (
   winnerList: IWinnerList[],
-): IFilteredWinners[] | undefined => {
+): IFilteredWinnerList[] | undefined => {
   return winnerList?.map(({ category, winners }: IWinnerList) => {
     return {
       category,

--- a/pages/event/[code].tsx
+++ b/pages/event/[code].tsx
@@ -11,7 +11,7 @@ import {
   EVENT_TEMPLATE,
   EVENT_TYPE,
   IFilteredEventItem,
-  IFilteredWinners,
+  IFilteredWinnerList,
 } from 'types/event'
 import { getUesrInfo } from '../api/user'
 import { useUserContext } from '@contexts/UserProvider'
@@ -32,7 +32,7 @@ const EventPage = (): JSX.Element => {
   const { id: userId } = useUserContext().user
   const [isLoading, setIsLoading] = useState(false)
   const [event, setEvent] = useState<IFilteredEventItem | undefined>()
-  const [winners, setWinners] = useState<IFilteredWinners[] | undefined>()
+  const [winners, setWinners] = useState<IFilteredWinnerList[] | undefined>()
 
   // 로그인 여부 확인
   const fetchUser = useCallback(async () => {

--- a/pages/event/[code].tsx
+++ b/pages/event/[code].tsx
@@ -2,6 +2,7 @@ import Header from '@domains/Header'
 import Icon from '@components/Icon'
 import { useRouter } from 'next/router'
 import styled from '@emotion/styled'
+import Text from '@components/Text'
 import { DEFAULT_MARGIN } from '@utils/constants/sizes'
 import { useCallback, useEffect, useState } from 'react'
 import { deleteEvent, getEventDetail, getEventWinners } from '../api/event'
@@ -112,10 +113,17 @@ const EventPage = (): JSX.Element => {
         />
         <TimeInfo start={event?.start as string} end={event?.end as string} />
       </EventContainer>
-      <WinnerModal
-        winners={winners || []}
-        isClosed={event?.status === 'CLOSED' ? true : false}
-      />
+
+      {/* eventProgressStatus 이벤트가 종료 되었을 경우 당첨자 모달 렌더링  */}
+      {event?.status === 'CLOSED' ? (
+        <>
+          <WinnerModal winners={winners || []} />
+        </>
+      ) : (
+        <Text color="WHITE" size="BASE" style={{ textAlign: 'center' }}>
+          이벤트가 종료되면 당첨자 목록을 확인할 수 있어요!
+        </Text>
+      )}
     </Wrapper>
   ) : (
     <></>

--- a/src/components/Swalert/RemoveAlert.tsx
+++ b/src/components/Swalert/RemoveAlert.tsx
@@ -1,0 +1,27 @@
+import Swal from 'sweetalert2'
+import { COLORS } from '@utils/constants/colors'
+
+const RemoveAlert = (
+  onRemove: any,
+  imageUrl: string,
+  confirmMsg: string,
+  canceleMsg: string,
+) => {
+  return Swal.fire({
+    imageUrl,
+    width: 320,
+    imageWidth: 200,
+    imageHeight: 200,
+    showCancelButton: true,
+    confirmButtonColor: COLORS.RED,
+    confirmButtonText: confirmMsg,
+    cancelButtonColor: COLORS.GREEN,
+    cancelButtonText: canceleMsg,
+  }).then((result) => {
+    if (result.isConfirmed) {
+      onRemove()
+    }
+  })
+}
+
+export default RemoveAlert

--- a/src/components/Swalert/index.tsx
+++ b/src/components/Swalert/index.tsx
@@ -1,3 +1,4 @@
 export { default as LogOutAlert } from './LogOutAlert'
 export { default as ErrorAlert } from './ErrorAlert'
 export { default as GiftGetAlert } from './GiftGetAlert'
+export { default as RemoveAlert } from './RemoveAlert'

--- a/src/domains/EventDetail/Cover.tsx
+++ b/src/domains/EventDetail/Cover.tsx
@@ -5,7 +5,7 @@ import styled from '@emotion/styled'
 import { COLORS } from '@utils/constants/colors'
 import { EVENT_FILTER, EVENT_TEMPLATE, EVENT_TYPE } from 'types/event'
 import { useCallback } from 'react'
-import Swalert from '@components/Swalert'
+import RemoveAlert from '@components/Swalert/RemoveAlert'
 import alertImage from '/public/alert.png'
 interface ICover {
   template: EVENT_TEMPLATE
@@ -66,7 +66,7 @@ const Cover = ({
           size="LARGE"
           style={{ margin: '16px 0 0 16px' }}
           onIconClick={() =>
-            Swalert(onRemoveEvent, alertImage.src, '삭제', '취소')
+            RemoveAlert(onRemoveEvent, alertImage.src, '삭제', '취소')
           }
         />
       </RemoveButton>

--- a/src/domains/EventDetail/WinnerModal.tsx
+++ b/src/domains/EventDetail/WinnerModal.tsx
@@ -3,46 +3,42 @@ import { COLORS } from '@utils/constants/colors'
 import Text from '@components/Text'
 import Modal from '@components/Modal'
 import MUIButton from '@components/MUIButton'
-import { IFilteredWinners } from 'types/event'
+import { IFilteredWinnerList, IFilteredWinner } from 'types/event'
 
 interface IWinnerModal {
-  winners: IFilteredWinners[] | []
-  isClosed: boolean
+  winners: IFilteredWinnerList[] | []
 }
 
-const WinnerModal = ({ winners, isClosed }: IWinnerModal): JSX.Element => {
-  console.log(winners)
-
+const WinnerModal = ({ winners }: IWinnerModal): JSX.Element => {
   return (
     <WinnerSection>
       <Modal title="당첨자 목록" btnStyle={{ ...winnerBtnStyle }}>
         <MUIButton
           style={{
-            backgroundColor: isClosed ? COLORS.GREEN : COLORS.TEXT_GRAY_DARK,
+            backgroundColor: COLORS.GREEN,
             ...winnerBtnStyle,
           }}>
           당첨자 목록 보기
         </MUIButton>
+
         <>
-          {isClosed ? (
-            winners?.map(({ category, winners }: IFilteredWinners, index) => {
-              return (
-                <section key={index}>
-                  <Text color="WHITE" size="MEDIUM">
-                    {category}
-                  </Text>
-                  <Text color="WHITE" size="BASE">
-                    {winners._id}
-                    {winners.name}
-                  </Text>
-                </section>
-              )
-            })
-          ) : (
-            <Text color="WHITE" size="BASE">
-              이벤트가 종료되면 당첨자 목록을 확인할 수 있어요!
-            </Text>
-          )}
+          {winners?.map(({ category, winners }: IFilteredWinnerList, index) => {
+            return (
+              <section key={index}>
+                <Text color="WHITE" size="MEDIUM">
+                  {category}
+                </Text>
+                {winners.map(({ _id, name }: IFilteredWinner) => {
+                  return (
+                    <Text color="WHITE" size="BASE">
+                      {_id}
+                      {name}
+                    </Text>
+                  )
+                })}
+              </section>
+            )
+          })}
         </>
       </Modal>
     </WinnerSection>

--- a/src/types/event.d.ts
+++ b/src/types/event.d.ts
@@ -65,10 +65,15 @@ export interface IWinner {
 }
 
 // 받아온 이벤트 당첨자 목록에 대한 정제 데이터 타입
-export interface IFilteredWinners {
+export interface IFilteredWinnerList {
   category: string
   winners: {
     _id: string
     name: string
   }[]
+}
+
+export interface IFilteredWinner {
+  _id: string
+  name: string
 }

--- a/src/types/event.d.ts
+++ b/src/types/event.d.ts
@@ -49,20 +49,26 @@ export interface IPagination {
   totalPages: number
 }
 
-// api 요청으로 받아오는 이벤트 당첨자 목록
-export interface IWinners {
+// api 요청으로 받아오는 이벤트 당첨자 목록 타입
+export interface IWinnerList {
   category: string
   winners: {
     id: number
     name: string
-  }
+  }[]
 }
 
-// 받아온 이벤트 당첨자 목록에 대한 정제 데이터
+// IWinnerList winners Type
+export interface IWinner {
+  id: number
+  name: string
+}
+
+// 받아온 이벤트 당첨자 목록에 대한 정제 데이터 타입
 export interface IFilteredWinners {
   category: string
   winners: {
     _id: string
     name: string
-  }
+  }[]
 }


### PR DESCRIPTION
## 🔥 Merge 대상이 Develop 브랜치가 맞는지 확인해주세요!!!

- [x] 반드시 확인 후 체크해주세요! ⁉️

## 🚀 PR 한 줄 요약

이벤트 종료에 따라 종료가 되었을 경우, 당첨자 목록 보이게 로직 개발

## 🚸 PR 세부 내용

- 서버에서 내려받은 이벤트 상태값(종료, 대기, 진행 중)에 따라 종료 되었을 경우, 모달 컴포넌트 렌더링
  -  모달 컴포넌트에서는 당첨자 정보 목록을 받아와서 화면에 뿌려줌
  - 이벤트가 종료되지 않았을 경우, 설명 문구 표시
- 당첨자 정보 로직 수정 -> interface, services로직 수정

- 삭제 alert 없어진 것 다시 되살렸습니다

- 추후 당첨자 정보 디자인 어떻게 구상할지 의논을 통해 디자인 개발

## 📸 스크린샷
진행 중인 이벤트
![image](https://user-images.githubusercontent.com/52727782/146675789-24b366ab-d427-4ce3-892f-c4f02b843968.png)

종료된 이벤트
![image](https://user-images.githubusercontent.com/52727782/146675794-eab4f3bf-26f4-439d-b06c-f0c3c43c5634.png)
당첨자 목록 보기 버튼 눌렀을 경우
![image](https://user-images.githubusercontent.com/52727782/146675799-6896b35e-1f05-4050-8ffd-9699871a3f2b.png)
