### PR TITLE
[GD-209] fix: 랜덤 페이지 선물 카드 zindex 수정 및 CardFlip 버튼 텍스트 수정

### DIFF
--- a/pages/random/[url].tsx
+++ b/pages/random/[url].tsx
@@ -257,7 +257,7 @@ const FadeInDownWrapper = styled.div`
   height: 100%;
   position: absolute;
   top: 0;
-  z-index: 99;
+  z-index: 9;
   animation: ${fadeInDown} 2s ease-out;
 `
 

--- a/src/domains/CardFlip/index.tsx
+++ b/src/domains/CardFlip/index.tsx
@@ -63,7 +63,7 @@ const CardFlip = ({ front, url, type }: ICardFlip): JSX.Element => {
             </a>
           ) : (
             <a href="#" onClick={clipboardCopy}>
-              저장하기
+              복사하기
             </a>
           )}
         </MUIButton>


### PR DESCRIPTION
## 🔥 Merge 대상이 Develop 브랜치가 맞는지 확인해주세요!!!

- [x] 반드시 확인 후 체크해주세요! ⁉️

## 🚀 PR 한 줄 요약

랜덤 페이지 선물 카드 zindex 수정

## 🚸 PR 세부 내용

- 선물 수령 후 Zindex 관련하여 헤더 컴포넌트의 페이지 이동이 일어나지 않던 문제를 개선하였습니다.
- 추가로 받은 선물이 텍스트 일 경우 저장하기 -> 복사하기 버튼으로 보여지도록 수정하였습니다.

<!-- 피드백을 반영한 부분이 있다면 해당 부분의 주석을 제거하고 사용해주세요!
## ⭕ 피드백 반영 사항

피드백 반영 사항에 대한 간단한 내용을 적어주세요.-->

## 📸 스크린샷

스크린샷을 첨부해주세요.
